### PR TITLE
Fix build for Windows/mingw32

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -479,13 +479,6 @@ if test "x$F77" = "xg95"; then
   LDFLAGS="-Wl,-framework,Accelerate $LDFLAGS"
 fi
 
-dnl *********************************************************************
-dnl checks for libraries now
-dnl Replace `main' with a function in -lm:
-if test "$FORTRAN_BLAS" != "no"; then
-  AC_F77_LIBRARY_LDFLAGS
-fi
-
 AC_SEARCH_LIBS(sqrt, [m])
 
 dnl find a valid blas and lapack library

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -82,8 +82,10 @@ XYCELINK = $(MSLINK)
 # build library (static & shared) for linking (w/libtool) into other codes
 lib_LTLIBRARIES = libxyce.la
 libxyce_la_SOURCES = $(XYCESOURCES)
-libxyce_la_LIBADD = $(XYCELINK)
-libxyce_la_LDFLAGS = $(AM_LDFLAGS) @XYCELIBS@
+libxyce_la_LIBADD = $(XYCELINK) @XYCELIBS@
+libxyce_la_LDFLAGS = $(AM_LDFLAGS) -no-undefined
+# XYCESOURCE may be empty - make sure libtool still knows that this is a C++ link
+libxyce_la_LIBTOOLFLAGS = --tag=CXX
 
 if BUILD_XYCE_BINARY
 


### PR DESCRIPTION
The first fix is simply to add `-no-undefined` to the link line,
since Xyce is not using this feature and it is required for creating
shared libraries on windows.

The second fix is to remove the AC_F77_LIBRARY_LDFLAGS macro. This
macro is required when mixing C++ and Fortran *source files*, but
here we are merely linking a Fortran library, which works fine without
this macro. In theory the macro should not be harmful, but in practice
it is unfortunately broken. I am working on fixing that separately in
upstream autoconf, but for the moment, since it is not required here,
remove it to fix the build.

Lastly, the XYCESOURCES variable can apparently be empty, which will
cause libtool to attempt a C link rather than a C++ link. Manually
specifying C++ mode fixes this.

cc @tvrusso - in case the "no pull requests" policy gets in the way, consider this a
request to make these three changes yourself :).