### PR TITLE
Fix mishandling of second derivatives

### DIFF
--- a/utils/ADMS/examples/hicum/Makefile
+++ b/utils/ADMS/examples/hicum/Makefile
@@ -15,7 +15,7 @@ clean:
 	rm -f N_DEV_ADMShicumL2va.C N_DEV_ADMShicumL2va.h *.o *.so* *.tex
 
 N_DEV_ADMShicumL2va.C: hicumL2V2p4p0.va  $(XyceADMSFILES)
-	admsXml -x -e $(ADMSDIR)/adms.implicit.xml -e $(ADMSDIR)/xyceVersion_nosac.xml -e $(ADMSDIR)/xyceBasicTemplates_nosac.xml -e $(ADMSDIR)/xyceAnalogFunction_nosac.xml -e $(ADMSDIR)/xyceHeaderFile_nosac.xml -e $(ADMSDIR)/xyceImplementationFile_nosac.xml -e $(ADMSDIR)/xyceOutVarsDoc.xml hicumL2V2p4p0.va
+	admsXml -x -e $(ADMSDIR)/adms.implicit.xml -e $(ADMSDIR)/xyceVersion_nosac.xml -e $(ADMSDIR)/xyceBasicTemplates_nosac.xml -e $(ADMSDIR)/xyceAnalogFunction_nosac.xml -e $(ADMSDIR)/xyceImplementationFile_nosac.xml  -e $(ADMSDIR)/xyceHeaderFile_nosac.xml -e $(ADMSDIR)/xyceOutVarsDoc.xml hicumL2V2p4p0.va
 	mv Q_234_OutputVars.tex Q_234_OutputVars.tex_borken
 	sed -e 's|\(r[a-z]*\)_|\1\\_|g' < Q_234_OutputVars.tex_borken > Q_234_OutputVars.tex
 	rm Q_234_OutputVars.tex_borken

--- a/utils/ADMS/examples/hicum_l0/Makefile
+++ b/utils/ADMS/examples/hicum_l0/Makefile
@@ -15,7 +15,7 @@ clean:
 	rm -f N_DEV_ADMShic0_full.C N_DEV_ADMShic0_full.h *.o *.so* *.tex
 
 N_DEV_ADMShic0_full.C: hicumL0V1p32.va  $(XyceADMSFILES)
-	admsXml -x -e $(ADMSDIR)/adms.implicit.xml  -e $(ADMSDIR)/xyceVersion_nosac.xml -e $(ADMSDIR)/xyceBasicTemplates_nosac.xml -e $(ADMSDIR)/xyceAnalogFunction_nosac.xml -e $(ADMSDIR)/xyceHeaderFile_nosac.xml -e $(ADMSDIR)/xyceImplementationFile_nosac.xml -e $(ADMSDIR)/xyceOutVarsDoc.xml hicumL0V1p32.va
+	admsXml -x -e $(ADMSDIR)/adms.implicit.xml  -e $(ADMSDIR)/xyceVersion_nosac.xml -e $(ADMSDIR)/xyceBasicTemplates_nosac.xml -e $(ADMSDIR)/xyceAnalogFunction_nosac.xml -e $(ADMSDIR)/xyceImplementationFile_nosac.xml  -e $(ADMSDIR)/xyceHeaderFile_nosac.xml -e $(ADMSDIR)/xyceOutVarsDoc.xml hicumL0V1p32.va
 #	emacs N_DEV_ADMShic0_full.C --batch --eval="(require 'cc-mode)" --eval="(c-set-offset 'substatement-open 0)" --eval="(c-set-offset 'arglist-intro 3)" --eval="(c-set-offset 'innamespace -2)" --eval="(setq-default indent-tabs-mode nil)" --eval='(indent-region (point-min) (point-max) nil)' -f save-buffer
 #	emacs N_DEV_ADMShic0_full.h --batch --eval="(require 'cc-mode)" --eval="(c-set-offset 'substatement-open 0)" --eval="(c-set-offset 'arglist-intro 3)" --eval="(c-set-offset 'innamespace -2)" --eval="(setq-default indent-tabs-mode nil)" --eval='(indent-region (point-min) (point-max) nil)' -f save-buffer
 

--- a/utils/ADMS/examples/mvs_2.0.0/Makefile
+++ b/utils/ADMS/examples/mvs_2.0.0/Makefile
@@ -14,10 +14,10 @@ clean:
 	rm -f N_DEV_ADMSmvs_2_0_0_hemt.C N_DEV_ADMSmvs_2_0_0_etsoi.C N_DEV_ADMSmvs_2_0_0_hemt.h N_DEV_ADMSmvs_2_0_0_etsoi.h *.o *.so*
 
 N_DEV_ADMSmvs_2_0_0_hemt.C: mvs_2_0_0_hemt.va  $(XyceADMSFILES)
-	admsXml -x -e $(ADMSDIR)/adms.implicit.xml  -e $(ADMSDIR)/xyceVersion_nosac.xml -e $(ADMSDIR)/xyceBasicTemplates_nosac.xml -e $(ADMSDIR)/xyceAnalogFunction_nosac.xml -e $(ADMSDIR)/xyceHeaderFile_nosac.xml -e $(ADMSDIR)/xyceImplementationFile_nosac.xml mvs_2_0_0_hemt.va
+	admsXml -x -e $(ADMSDIR)/adms.implicit.xml  -e $(ADMSDIR)/xyceVersion_nosac.xml -e $(ADMSDIR)/xyceBasicTemplates_nosac.xml -e $(ADMSDIR)/xyceAnalogFunction_nosac.xml -e $(ADMSDIR)/xyceImplementationFile_nosac.xml -e $(ADMSDIR)/xyceHeaderFile_nosac.xml mvs_2_0_0_hemt.va
 #	emacs N_DEV_ADMSmvs_2_0_0_hemt.C --batch --eval="(require 'cc-mode)" --eval="(c-set-offset 'substatement-open 0)" --eval="(c-set-offset 'arglist-intro 3)" --eval="(c-set-offset 'innamespace -2)" --eval="(setq-default indent-tabs-mode nil)" --eval='(indent-region (point-min) (point-max) nil)' -f save-buffer
 
 N_DEV_ADMSmvs_2_0_0_etsoi.C: mvs_2_0_0_etsoi.va  $(XyceADMSFILES)
-	admsXml -x -e $(ADMSDIR)/adms.implicit.xml  -e $(ADMSDIR)/xyceVersion_nosac.xml -e $(ADMSDIR)/xyceBasicTemplates_nosac.xml -e $(ADMSDIR)/xyceAnalogFunction_nosac.xml -e $(ADMSDIR)/xyceHeaderFile_nosac.xml -e $(ADMSDIR)/xyceImplementationFile_nosac.xml mvs_2_0_0_etsoi.va
+	admsXml -x -e $(ADMSDIR)/adms.implicit.xml  -e $(ADMSDIR)/xyceVersion_nosac.xml -e $(ADMSDIR)/xyceBasicTemplates_nosac.xml -e $(ADMSDIR)/xyceAnalogFunction_nosac.xml -e $(ADMSDIR)/xyceImplementationFile_nosac.xml -e $(ADMSDIR)/xyceHeaderFile_nosac.xml mvs_2_0_0_etsoi.va
 #	emacs N_DEV_ADMSmvs_2_0_0_etsoi.C --batch --eval="(require 'cc-mode)" --eval="(c-set-offset 'substatement-open 0)" --eval="(c-set-offset 'arglist-intro 3)" --eval="(c-set-offset 'innamespace -2)" --eval="(setq-default indent-tabs-mode nil)" --eval='(indent-region (point-min) (point-max) nil)' -f save-buffer
 

--- a/utils/ADMS/html_params.xml
+++ b/utils/ADMS/html_params.xml
@@ -284,6 +284,9 @@
                   </td>
                   <td>
                     <admst:text format="%(insource)"/>
+                    <admst:if test="[exists(derivate)]">
+                      <admst:text format="(derivate=%(derivate))"/>
+                    </admst:if>
                   </td>
                   <td><admst:text format="%(static).%(dynamic) "/></td>
                   <td><admst:text format="%(TemperatureDependent)"/></td>
@@ -548,6 +551,9 @@
                   </td>
                   <td>
                     <admst:text format="%(insource)"/>
+                    <admst:if test="[exists(derivate)]">
+                      <admst:text format="(derivate=%(derivate))"/>
+                    </admst:if>
                   </td>
                   <td><admst:text format="%(static).%(dynamic) "/></td>
                   <td><admst:text format="%(TemperatureDependent)"/></td>

--- a/utils/ADMS/xyceBasicTemplates_nosac.xml
+++ b/utils/ADMS/xyceBasicTemplates_nosac.xml
@@ -799,7 +799,21 @@ struct Traits: public DeviceTraits&lt;Model, Instance
         <admst:join select="probe" separator=",\n">
           <admst:text format="d_%(../name)_d%(nature)_%(branch/pnode)_%(branch/nnode)(0.0)"/>
         </admst:join>
-    </admst:if>
+        <!-- initializers for second derivative variables if needed -->
+        <admst:variable name="myVar" path="."/>
+        <admst:for-each select="probe">
+          <admst:variable name="myprobe" path="."/>
+          <admst:if test="[$myVar/insource='yes' and $doSecondDerivs='yes']">
+            <admst:if test="[exists($myVar/ddxprobe/branch/pnode[.=$myprobe/branch/pnode or .=$myprobe/branch/nnode])]">
+              <admst:text format=",\n"/>
+              <admst:join select="$myVar/probe" separator=",\n">
+                <admst:text
+                    format="d_%($myVar/name)_d%($myprobe/nature)_%($myprobe/branch/pnode)_%($myprobe/branch/nnode)_d%(./nature)_%(./branch/pnode)_%(./branch/nnode)(0.0)"/>
+              </admst:join>
+            </admst:if>
+          </admst:if>
+        </admst:for-each>
+      </admst:if>
     </admst:join>
     <!-- now initialize the LIDs: -->
     <admst:if test="[exists(node[grounded='no'])]">

--- a/utils/ADMS/xyceHeaderFile_nosac.xml
+++ b/utils/ADMS/xyceHeaderFile_nosac.xml
@@ -43,8 +43,12 @@
 
 <admst:for-each select="/module">
   <admst:variable name="thisModule" select="%(.)"/>
-  <admst:if test="variable[insource='yes' and derivate='yes']">
-    <admst:variable name="doSecondDerivatives" select="yes"/>
+  <admst:if test="[exists(variable[insource='yes' and exists(derivate)
+                  and derivate='yes'])
+                  or
+                  exists(/module/block/variable[insource='yes' and exists(derivate)
+                  and derivate='yes'])]">
+    <admst:variable name="doSecondDerivs" select="yes"/>
   </admst:if>
   <!-- Set up some useful variables: the N_DEV_(foo) class, and its
        related Instance and Model classes -->

--- a/utils/ADMS/xyceImplementationFile_nosac.xml
+++ b/utils/ADMS/xyceImplementationFile_nosac.xml
@@ -126,8 +126,12 @@
     </admst:if>
   </admst:for-each>
   <admst:message format="Top-level analog/code assigns to %(count(analog/code/@assignedVars)) variables.\n"/>
-  <admst:if test="variable[insource='yes' and exists(derivate) and derivate='yes']">
-    <admst:variable name="doSecondDerivatives" select="yes"/>
+  <admst:if test="[exists(variable[insource='yes' and exists(derivate)
+                  and derivate='yes'])
+                  or
+                  exists(/module/block/variable[insource='yes' and exists(derivate)
+                  and derivate='yes'])]">
+    <admst:variable name="doSecondDerivs" select="yes"/>
   </admst:if>
   <admst:if test="[exists(@optnodes)]">
     <admst:message format="Module has %(count(@optnodes)) optional nodes:\n"/>

--- a/utils/buildxyceplugin.cmake.in
+++ b/utils/buildxyceplugin.cmake.in
@@ -49,8 +49,8 @@ runadms()
 {
     ${XyceInstDir}/bin/admsXml -D__XYCE__ -x -e ${xmldir}/adms.implicit.xml -e ${xmldir}/xyceVersion_nosac.xml  -e ${xmldir}/xyceBasicTemplates_nosac.xml \
             -e ${xmldir}/xyceAnalogFunction_nosac.xml \
-            -e ${xmldir}/xyceHeaderFile_nosac.xml \
             -e ${xmldir}/xyceImplementationFile_nosac.xml $1 \
+            -e ${xmldir}/xyceHeaderFile_nosac.xml \
             >> buildxyceplugin.log 2>&1
     return $?
 }

--- a/utils/buildxyceplugin.cmake.in
+++ b/utils/buildxyceplugin.cmake.in
@@ -49,8 +49,8 @@ runadms()
 {
     ${XyceInstDir}/bin/admsXml -D__XYCE__ -x -e ${xmldir}/adms.implicit.xml -e ${xmldir}/xyceVersion_nosac.xml  -e ${xmldir}/xyceBasicTemplates_nosac.xml \
             -e ${xmldir}/xyceAnalogFunction_nosac.xml \
-            -e ${xmldir}/xyceImplementationFile_nosac.xml $1 \
-            -e ${xmldir}/xyceHeaderFile_nosac.xml \
+            -e ${xmldir}/xyceImplementationFile_nosac.xml \
+            -e ${xmldir}/xyceHeaderFile_nosac.xml $1 \
             >> buildxyceplugin.log 2>&1
     return $?
 }

--- a/utils/buildxyceplugin.in
+++ b/utils/buildxyceplugin.in
@@ -68,8 +68,8 @@ runadms()
 {
     admsXml -D__XYCE__ -x -e ${xmldir}/adms.implicit.xml -e ${xmldir}/xyceVersion_nosac.xml  -e ${xmldir}/xyceBasicTemplates_nosac.xml \
             -e ${xmldir}/xyceAnalogFunction_nosac.xml \
-            -e ${xmldir}/xyceImplementationFile_nosac.xml $1 \
-            -e ${xmldir}/xyceHeaderFile_nosac.xml \
+            -e ${xmldir}/xyceImplementationFile_nosac.xml \
+            -e ${xmldir}/xyceHeaderFile_nosac.xml $1 \
             >> buildxyceplugin.log 2>&1
     return $?
 }

--- a/utils/buildxyceplugin.in
+++ b/utils/buildxyceplugin.in
@@ -68,8 +68,8 @@ runadms()
 {
     admsXml -D__XYCE__ -x -e ${xmldir}/adms.implicit.xml -e ${xmldir}/xyceVersion_nosac.xml  -e ${xmldir}/xyceBasicTemplates_nosac.xml \
             -e ${xmldir}/xyceAnalogFunction_nosac.xml \
-            -e ${xmldir}/xyceHeaderFile_nosac.xml \
             -e ${xmldir}/xyceImplementationFile_nosac.xml $1 \
+            -e ${xmldir}/xyceHeaderFile_nosac.xml \
             >> buildxyceplugin.log 2>&1
     return $?
 }


### PR DESCRIPTION
A long time ago, when I implemented ddx in Xyce/ADMS, I made a huge error in handling of second derivatives that caused massive bloat in codes that didn't even need them.  In fixing that, I removed all that bloat but also managed to disable generation of some second derivative variable declaration when it *WAS* needed.

Second derivatives are absolutely required when any variable that is assigned a value using "ddx" is then used in any computation that ends up in a contribution.  That's because the derivatives needed for the jacobian of any expression that is already a derivative are in fact second derivatives now.

I discovered this today when attempting to build the ekv3 version 302 code that Matthias Bucher has released under a much less restrictive license than the Xyce team was forced to obey years ago when we signed the NDA for it.

The new version of ekv3 has some output variables that use ddx, but somehow also manage to get into contributions.

The changes here accomplish several things:
  - Set the correctly named "doSecondDerivs" variable in xyceImplementationFile_nosac.xml instead of the variable "doSecondDerivatives" (the former is actually used by xyceBasicTemplates_nosac, and the latter is never, ever used).
  - Fix the logic in xyceImplementationFile_nosac so that the variable is actually set when it needs to be, which is when *any* variable must have second derivatives.  Previously it only recognized when top level variables needed it.
  - add code to initialize second derivative variables when they happen to be instance variables.
  - make sure that all Makefiles in the ADMS directory call the xyceHeaderFile_nosac.xml file *after* xyceImplementationFile_nosac.xml, because it is the latter file that sets "doSecondDerivs", but the former file needs this set properly.
  - change both versions of buildxyceplugin to get the order of header/implementation right.

With these changes I can regenerate all of the current ADMS devices (using "generate_ADMS.sh") and see NO differences.  (Well, no differences that are caused by this change.  There are differences because the devices were not regenerated after the ternary operator fix, but those are good differences.)

And with these changes, I can use buildxyceplugin to generate a plugin for the ekv3 that compiles [Dietmar Warning's fork of the ekv3model repo](https://github.com/dwarning/ekv3model).  I have NOT attempted to *run* that model yet, but it does compile into a plugin with these changes.  It puked with undeclared variable problems before.

Closes #104 
