### PR TITLE
Fix bad memory access in packed restart

### DIFF
--- a/src/DeviceModelPKG/Core/N_DEV_DeviceMgr.C
+++ b/src/DeviceModelPKG/Core/N_DEV_DeviceMgr.C
@@ -5883,7 +5883,7 @@ bool DeviceMgr::dumpRestartData(
     comm->pack(&(solState_.ltraTimeIndex_), 1, buf, bsize, pos);
     comm->pack(&(solState_.ltraTimeHistorySize_), 1, buf, bsize, pos);
     comm->pack(&(size), 1, buf, bsize, pos);
-    comm->pack(&(solState_.ltraTimePoints_[0]), size, buf, bsize, pos);
+    comm->pack(solState_.ltraTimePoints_.data(), size, buf, bsize, pos);
   }
   else
   {
@@ -5949,7 +5949,7 @@ bool DeviceMgr::restoreRestartData(char * buf, int bsize, int & pos, Parallel::C
     int size=0;
     comm->unpack(buf, bsize, pos, &(size), 1);
     solState_.ltraTimePoints_.resize(size);
-    comm->unpack(buf, bsize, pos, &(solState_.ltraTimePoints_[0]), size);
+    comm->unpack(buf, bsize, pos, solState_.ltraTimePoints_.data(), size);
   }
   else
   {

--- a/src/DeviceModelPKG/Core/N_DEV_DeviceState.C
+++ b/src/DeviceModelPKG/Core/N_DEV_DeviceState.C
@@ -166,7 +166,7 @@ Pack<Device::DeviceState>::pack(const Device::DeviceState &device_state, char * 
   //----- pack double data
   length = device_state.data.size();
   comm->pack( &length, 1, buf, bsize, pos );
-  comm->pack( &(device_state.data[0]), length, buf, bsize, pos );
+  comm->pack( device_state.data.data(), length, buf, bsize, pos );
 
   //----- pack int data
   length = device_state.dataInt.size();
@@ -196,7 +196,7 @@ Pack<Device::DeviceState>::unpack(Device::DeviceState &device_state, char * buf,
   //----- unpack data
   comm->unpack( buf, bsize, pos, &length, 1 );
   device_state.data.resize(length);
-  comm->unpack( buf, bsize, pos, &(device_state.data[0]), length );
+  comm->unpack( buf, bsize, pos, device_state.data.data(), length );
 
   //----- unpack int data
   comm->unpack( buf, bsize, pos, &length, 1 );


### PR DESCRIPTION
For a very long time (longer than git public history), the DeviceMgr function "dumpRestartData" and "restoreRestartData" have had an error in dumping "ltraTimePoints_" --- both unconditionally access the pointer to ltraTimePoints_[0] even if the vector is empty.  This is a recipe for undefined behavior.

Undefined behavior in this case means "always worked before up to and including FreeBSD 13.3 but suddenly throws illegal instruction errors in FreeBSD 13.4, presumably due to a Clang update."  Apparently, that pointer is invalid when the vector has zero size, and now clang pukes.

Because unpacked restart loops over the size of ltraTimePoints_, it does nothing to the vector if size is zero.

Several packed restart test cases started failing on my system because of this error.

This commit replaces several uses of &(vector[0]) with vector.data(), which is the safer way to do what is trying to be done, and does the right thing when the vector is empty (provided one doesn't try to dereference and index off of the pointer received, of course).

This fix is exactly the same as the one applied last February in Github commit 92e522bf5.  That commit explicitly said it didn't fix all of this sort of error, just the few that got spotted with respect to certain internal bug reports.  This commit fixes a few more of them, and makes no attempt to fix them all.

closes #113
closes GH-113