### PR TITLE
Fix illegal instruction errors on FreeBSD with clang

### DIFF
--- a/src/AnalysisPKG/N_ANP_SweepParam.C
+++ b/src/AnalysisPKG/N_ANP_SweepParam.C
@@ -915,7 +915,7 @@ Pack<Analysis::SweepParam>::pack(const Analysis::SweepParam &param, char * buf, 
     const std::vector<double> &double_vector = param.valList;
     length = (int) double_vector.size();
     comm->pack( &length, 1, buf, bsize, pos );
-    comm->pack( &double_vector[0], length, buf, bsize, pos );
+    comm->pack( double_vector.data(), length, buf, bsize, pos );
   }
 
   //pack dataSetName
@@ -1088,7 +1088,7 @@ Pack<Analysis::SweepParam>::unpack(Analysis::SweepParam &param, char * pB, int b
     comm->unpack( pB, bsize, pos, &vector_size, 1 );
     std::vector<double> &x = param.valList;
     x.resize(vector_size, 0.0);
-    comm->unpack( pB, bsize, pos, &(x[0]), vector_size );
+    comm->unpack( pB, bsize, pos, x.data(), vector_size );
   }
   //unpack dataSetName 
   comm->unpack( pB, bsize, pos, &length, 1 );

--- a/src/LinearAlgebraServicesPKG/N_LAS_BlockSystemHelpers.C
+++ b/src/LinearAlgebraServicesPKG/N_LAS_BlockSystemHelpers.C
@@ -253,9 +253,9 @@ std::vector<Teuchos::RCP<Parallel::ParMap> > createBlockParMaps( int numBlocks,
 
    // Extract the global indices.
    const Parallel::EpetraParMap& e_pmap = dynamic_cast<const Parallel::EpetraParMap&>(pmap);
-   e_pmap.petraMap()->MyGlobalElements( &BaseGIDs[0] );
+   e_pmap.petraMap()->MyGlobalElements( BaseGIDs.data() );
    const Parallel::EpetraParMap& e_omap = dynamic_cast<const Parallel::EpetraParMap&>(omap);
-   e_omap.petraMap()->MyGlobalElements( &oBaseGIDs[0] );
+   e_omap.petraMap()->MyGlobalElements( oBaseGIDs.data() );
    
    int gnd_node = 0;  // Will be decremented before first use.
 

--- a/src/LinearAlgebraServicesPKG/N_LAS_EpetraGraph.C
+++ b/src/LinearAlgebraServicesPKG/N_LAS_EpetraGraph.C
@@ -58,7 +58,7 @@ EpetraGraph::EpetraGraph(  const Parallel::ParMap & solution_overlap,
               const std::vector<std::vector<int> >& rcData)
   {
     const Epetra_Map* epetraMap = dynamic_cast<const Parallel::EpetraParMap&>(solution_overlap).petraMap();
-    epetraGraph_ = Teuchos::rcp( new Epetra_CrsGraph( Copy, *epetraMap, &numIndicesPerRow[0] ) );
+    epetraGraph_ = Teuchos::rcp( new Epetra_CrsGraph( Copy, *epetraMap, numIndicesPerRow.data() ) );
 
     int numLocalRows_Overlap = rcData.size();
     for(int i = 0; i < numLocalRows_Overlap; ++i)

--- a/src/LinearAlgebraServicesPKG/N_LAS_FilteredMatrix.C
+++ b/src/LinearAlgebraServicesPKG/N_LAS_FilteredMatrix.C
@@ -633,7 +633,7 @@ void FilteredMatrix::addToMatrix( Matrix & A, double alpha )
 {
   if (!isEmpty())
   {
-    double* scaledValues = &values_[0];
+    double* scaledValues = values_.data();
     if (alpha != 1.0)
     {
       int i=0;

--- a/src/NonlinearSolverPKG/N_NLS_SensitivityResiduals.C
+++ b/src/NonlinearSolverPKG/N_NLS_SensitivityResiduals.C
@@ -711,7 +711,7 @@ bool computeSparseIndices ( const int iparam,
     {
       myGhostNodesGIDs[ myStartIdx + i ] = ghostNodes[i];
     }
-    dfdpPtrVector->pdsComm()->sumAll( &myGhostNodesGIDs[0], &totalGhostNodesGIDs[0], totalIdx );
+    dfdpPtrVector->pdsComm()->sumAll( myGhostNodesGIDs.data(), totalGhostNodesGIDs.data(), totalIdx );
     std::sort( totalGhostNodesGIDs.begin(), totalGhostNodesGIDs.end() );
     totalGhostNodesGIDs.erase( std::unique( totalGhostNodesGIDs.begin(), totalGhostNodesGIDs.end() ), totalGhostNodesGIDs.end() );
 

--- a/src/ParallelDistPKG/N_PDS_MPI.C
+++ b/src/ParallelDistPKG/N_PDS_MPI.C
@@ -488,7 +488,7 @@ GatherV(
     if (rank == root) {
       dest.resize(size);
       for (unsigned i = 0; i < size; ++i)
-        dest[i] = std::string(&receive[receive_displacement[i]], &receive[receive_displacement[i] + receive_count[i]]);
+        dest[i] = std::string(&receive[receive_displacement[i]],receive_count[i]);
     }
   }
   else {
@@ -537,7 +537,7 @@ AllGatherV(
 
     dest.resize(size);
     for (unsigned i = 0; i < size; ++i)
-      dest[i] = std::string(&receive[receive_displacement[i]], &receive[receive_displacement[i] + receive_count[i]]);
+      dest[i] = std::string(&receive[receive_displacement[i]], receive_count[i]);
   }
   else {
     dest.resize(1);

--- a/src/ParallelDistPKG/N_PDS_MPI.h
+++ b/src/ParallelDistPKG/N_PDS_MPI.h
@@ -491,7 +491,7 @@ AllReduce(MPI_Comm mpi_comm, MPI_Op op, std::vector<T> &dest)
   if (mpi_parallel_run(mpi_comm)) {
     std::vector<T> source(dest);
 
-    if (MPI_Allreduce(&source[0], &dest[0], (int) dest.size(), Datatype<T>::type(), op, mpi_comm) != MPI_SUCCESS )
+    if (MPI_Allreduce(source.data(), dest.data(), (int) dest.size(), Datatype<T>::type(), op, mpi_comm) != MPI_SUCCESS )
       throw std::runtime_error("MPI_Allreduce failed");
   }
 }

--- a/src/ParallelDistPKG/N_PDS_Migrate.h
+++ b/src/ParallelDistPKG/N_PDS_Migrate.h
@@ -225,7 +225,7 @@ operator()( std::vector<int> const & pList,
       max_size = std::max( max_size, PackTraits<KT>::size( *citKL ) );
 
     int importCnt;
-    distributor.CreateFromSends( exportCnt, &(pList[0]), true, importCnt ); 
+    distributor.CreateFromSends( exportCnt, pList.data(), true, importCnt ); 
 
     double d_max_size = static_cast<double>(max_size);
     double d_max_all;
@@ -246,10 +246,10 @@ operator()( std::vector<int> const & pList,
     for( int i = 0; citKL != cendKL; ++citKL, ++i )
     {
       pos = max_all * i;
-      PackTraits<KT>::pack( *citKL, &(exports_[0]), (max_all*exportCnt ), pos, comm_ );
+      PackTraits<KT>::pack( *citKL, exports_.data(), (max_all*exportCnt ), pos, comm_ );
     }
 
-    distributor.Do( &(exports_[0]), max_all, importSize_, imports_ );
+    distributor.Do( exports_.data(), max_all, importSize_, imports_ );
 
     oKeys.resize( importCnt );
     for( int i = 0; i < importCnt; ++i )
@@ -300,7 +300,7 @@ operator()( std::vector<int> const & pList,
                  + PackTraits<DT>::size( *(citDM->second) ) );
 
     int importCnt;
-    distributor.CreateFromSends( exportCnt, &(pList[0]), true, importCnt ); 
+    distributor.CreateFromSends( exportCnt, pList.data(), true, importCnt ); 
 
     double d_max_size = static_cast<double>(max_size);
     double d_max_all;
@@ -325,7 +325,7 @@ operator()( std::vector<int> const & pList,
       PackTraits<DT>::pack( *(citDM->second), &(exports_[0]), (max_all*exportCnt ), pos, comm_ );
     }
 
-    distributor.Do( &(exports_[0]), max_all, importSize_, imports_ );
+    distributor.Do( exports_.data(), max_all, importSize_, imports_ );
 
     oData.clear();
     KT key;
@@ -380,7 +380,7 @@ rvs( std::vector<int> const & pList,
     int importCnt = pList.size();
     int exportCnt;
 
-    distributor.CreateFromSends( importCnt, &(pList[0]), true, exportCnt );
+    distributor.CreateFromSends( importCnt, pList.data(), true, exportCnt );
 
     if( exportCnt != (int)keys.size() )
       Xyce::Report::DevelFatal().in("Xyce::Parallel::Migrate::rvs")
@@ -413,11 +413,11 @@ rvs( std::vector<int> const & pList,
     for( ; citKL != cendKL; ++citKL, ++i )
     {
       pos = max_all * i;
-      PackTraits<KT>::pack( *citKL, &(exports_[0]), (max_all*exportCnt ), pos, comm_ );
-      PackTraits<DT>::pack( *(iData[*citKL]), &(exports_[0]), (max_all*exportCnt ), pos, comm_ );
+      PackTraits<KT>::pack( *citKL, exports_.data(), (max_all*exportCnt ), pos, comm_ );
+      PackTraits<DT>::pack( *(iData[*citKL]), exports_.data(), (max_all*exportCnt ), pos, comm_ );
     }
 
-    distributor.DoReverse( &(exports_[0]), max_all, importSize_, imports_ );
+    distributor.DoReverse( exports_.data(), max_all, importSize_, imports_ );
 
     oData.clear();
     KT key;

--- a/src/TopoManagerPKG/N_TOP_ParLSUtil.C
+++ b/src/TopoManagerPKG/N_TOP_ParLSUtil.C
@@ -609,8 +609,8 @@ bool ParLSUtil::testVoltageNodeConnectivity_()
     ncomm[procID*max_num_proc+i] = (*cg_i).second.size();
     i++;
   }
-  comm.sumAll(&pcomm[0], &pcomm_all[0], tmpSize);
-  comm.sumAll(&ncomm[0], &ncomm_all[0], tmpSize);
+  comm.sumAll(pcomm.data(), pcomm_all.data(), tmpSize);
+  comm.sumAll(ncomm.data(), ncomm_all.data(), tmpSize);
 
   std::vector<int> sendBuf;
   std::vector<int> src;

--- a/src/TopoManagerPKG/N_TOP_Topology.C
+++ b/src/TopoManagerPKG/N_TOP_Topology.C
@@ -509,7 +509,7 @@ void Topology::removeFloatingNodes(Device::DeviceMgr &device_manager)
 
           // Wait for a response from the other processors on whether they have 
           // any of these floating nodes.
-          pdsManager_.getPDSComm()->maxAll( &tmpNodeCnt[0], &nodeCnt[0], tFNodes[proc] );
+          pdsManager_.getPDSComm()->maxAll( tmpNodeCnt.data(), nodeCnt.data(), tFNodes[proc] );
 
           std::vector< Xyce::NodeID >::iterator it = floatingDevs.begin();
           for (int i=0; it != floatingDevs.end(); ++it, ++i)
@@ -558,7 +558,7 @@ void Topology::removeFloatingNodes(Device::DeviceMgr &device_manager)
           }
 
           // Now sum the tmpNodeCnt to see which voltage nodes are on other processors. 
-          pdsManager_.getPDSComm()->maxAll( &tmpNodeCnt[0], &nodeCnt[0], tFNodes[proc] );
+          pdsManager_.getPDSComm()->maxAll( tmpNodeCnt.data(), nodeCnt.data(), tFNodes[proc] );
         }
 
         // Clean up.


### PR DESCRIPTION
On FreeBSD 13.4 with clang 18.1.6, parallel Xyce has started crashing on over 1900 netlists in the test suite.  A previously built binary from FreeBSD 13.3 (with Clang 17.something) still runs fine.

These failures are almost all due to attempts to access a pointer to the underlying storage of an STL vector, without checking that the vector isn't empty.  This introduces a presumption that the STL implementation always allocates some storage even if the vector is empty, which is clearly NOT the case beginning with FreeBSD 13.4 with Clang 18.

The code in each of these cases looks something like trying to pass &(vector[0]) to a function that expects a double pointer.  The result on BSD is that the code exits with an illegal instruction error inside an assertion that is doing vector "operator[]" bounds checking.

Replacing each of these `&(vector[0])` usages with `vector.data()` bandaids the problem --- it "fixes the glitch" in the sense that `data()` doesn't crash, but it only works because in fact the downstream code doesn't actually try to dereference the pointer it receives.

I should note in passing that ".data()" was not an option back in the day when most of this code was written, it was added after C++98. Back then, the *right* thing to have done would have been to check the size of the vector before trying to access its underlying storage and not to try to get it if there was nothing stored.  That would still be a reasonable option today, but I opted for the more compact, simpler fix.

`data()` is NOT guaranteed to return a non-NULL pointer if
the vector is empty, but at least it doesn't crash.   It remains
unsafe to dereference the pointer, but that's not a problem in any of
these failures --- the pointer is basically never used after obtaining
it, because other indications of the emptiness of the vector are
protecting it.

However a very large number of test failures are due to a strange use in two spots in N_PDS_MPI.C of the std::string constructor being called with two char pointer arguments,

    somestring = std::string(&receive[offset], &receive[offset + count]);

presumably intended to mean "copy the string from this pointer up to that one", but this usage is not apparently part of the standard and I
can find no documentation that it is legal.   Replacing one such
instance of this usage with

      somestring = std::string(&receive[offset], count);

fixes a very large number of failures (some 900 of them).  Fixing a second occurrance of this same thing fixes another 46.

This single commit is actually a squash of 7 commits I actually made in addressing this issue, each fixing a subset of tests en masse, but the details and extensive commentary I made in that process are uninteresting.  Applying this single squashed commit fixes almost all of my parallel test failures.  GH-114 fixes a few additional restart tests that failed in serial for the same reason, and both that PR and this need to be applied to fix both GH-114 and GH-115.

A small number of failures are actually due to exactly the same issue in a couple of places inside Trilinos.  See issue GH-115 for more details on that.

I have ONLY fixed these `&vector[0]` things that actually get executed during the course of the test suite.  I know that many more are present throughout Xyce, but clearly aren't being covered during a run of the test suite so I left them alone.  I consider them undefused landmines that are going to take someone's leg off someday, so the Xyce team should probably go through the code carefully and fix the rest of them.

The team might also consider whether it's a good idea to be peeking behind the encapsulation of STL vectors so often --- is it always necessary to get a pointer to the raw underlying storage (obviously, in some cases it may be necessary for efficiency's sake).

This commit closes GH-115.