### PR TITLE
Replace nonstandard ASSERT with standard assert

### DIFF
--- a/src/LinearAlgebraServicesPKG/ksparse/spalloc.c
+++ b/src/LinearAlgebraServicesPKG/ksparse/spalloc.c
@@ -100,6 +100,8 @@ static char RCSid[] =
 #include "spmatrix.h"
 #include "spdefs.h"
 
+#include <assert.h>
+
 ElementPtr *returned_elements;
 int num_return_cols, *num_returned_elements;
 
@@ -726,7 +728,7 @@ int I;
 
 
 /* Begin `spDestroy'. */
-    ASSERT( IS_SPARSE( Matrix ) );
+    assert( IS_SPARSE( Matrix ) );
 
 /* Deallocate the vectors that are located in the matrix frame. */
     FREE( Matrix->IntToExtColMap );
@@ -811,7 +813,7 @@ spError( char* eMatrix )
 /* Begin `spError'. */
 
     if (eMatrix != NULL)
-    {   ASSERT(((MatrixPtr)eMatrix)->ID == SPARSE_ID);
+    {   assert(((MatrixPtr)eMatrix)->ID == SPARSE_ID);
         return ((MatrixPtr)eMatrix)->Error;
     }
     else return spNO_MEMORY;   /* This error may actually be spPANIC,
@@ -847,7 +849,7 @@ spWhereSingular( char* eMatrix, int* pRow, int* pCol )
 MatrixPtr Matrix = (MatrixPtr)eMatrix;
 
 /* Begin `spWhereSingular'. */
-    ASSERT( IS_SPARSE( Matrix ) );
+    assert( IS_SPARSE( Matrix ) );
 
     if (Matrix->Error == spSINGULAR OR Matrix->Error == spZERO_DIAG)
     {   *pRow = Matrix->SingularRow;
@@ -884,7 +886,7 @@ spGetSize( char* eMatrix, BOOLEAN External )
 MatrixPtr Matrix = (MatrixPtr)eMatrix;
 
 /* Begin `spGetSize'. */
-    ASSERT( IS_SPARSE( Matrix ) );
+    assert( IS_SPARSE( Matrix ) );
 
 #if TRANSLATE
     if (External)
@@ -918,7 +920,7 @@ spSetReal( char* eMatrix )
 {
 /* Begin `spSetReal'. */
 
-    ASSERT( IS_SPARSE( (MatrixPtr)eMatrix ) AND REAL);
+    assert( IS_SPARSE( (MatrixPtr)eMatrix ) AND REAL);
     ((MatrixPtr)eMatrix)->Complex = NO;
     return;
 }
@@ -929,7 +931,7 @@ spSetComplex( char* eMatrix )
 {
 /* Begin `spSetComplex'. */
 
-    ASSERT( IS_SPARSE( (MatrixPtr)eMatrix ) AND spCOMPLEX);
+    assert( IS_SPARSE( (MatrixPtr)eMatrix ) AND spCOMPLEX);
     ((MatrixPtr)eMatrix)->Complex = YES;
     return;
 }
@@ -958,7 +960,7 @@ spFillinCount( char* eMatrix )
 {
 /* Begin `spFillinCount'. */
 
-    ASSERT( IS_SPARSE( (MatrixPtr)eMatrix ) );
+    assert( IS_SPARSE( (MatrixPtr)eMatrix ) );
     return ((MatrixPtr)eMatrix)->Fillins;
 }
 
@@ -968,6 +970,6 @@ spElementCount( char* eMatrix )
 {
 /* Begin `spElementCount'. */
 
-    ASSERT( IS_SPARSE( (MatrixPtr)eMatrix ) );
+    assert( IS_SPARSE( (MatrixPtr)eMatrix ) );
     return ((MatrixPtr)eMatrix)->Elements;
 }

--- a/src/LinearAlgebraServicesPKG/ksparse/spbuild.c
+++ b/src/LinearAlgebraServicesPKG/ksparse/spbuild.c
@@ -27,7 +27,7 @@ All additions and changes are under the following:
 */
 
 #include "spice.h"
-
+#include <assert.h>
 /*
 #define CHECK_IND
 */
@@ -148,7 +148,7 @@ register  ElementPtr  pElement;
 register  int  I;
 
 /* Begin `spClear'. */
-    ASSERT( IS_SPARSE( Matrix ) );
+    assert( IS_SPARSE( Matrix ) );
     Matrix->Format = FORMAT_SPARSE;
 
 /* Clear matrix. */
@@ -231,7 +231,7 @@ RealNumber  *pElement;
 void  Translate();
 
 /* Begin `spGetElement'. */
-    ASSERT( IS_SPARSE( Matrix ) AND Row >= 0 AND Col >= 0 );
+    assert( IS_SPARSE( Matrix ) AND Row >= 0 AND Col >= 0 );
     if (Matrix->Format != FORMAT_SPARSE)
       spExpandFormat (Matrix);
 
@@ -239,7 +239,7 @@ void  Translate();
         return &Matrix->TrashCan.Real;
 
 #if NOT TRANSLATE
-    ASSERT(Matrix->NeedsOrdering);
+    assert(Matrix->NeedsOrdering);
 #endif
 
 #if TRANSLATE
@@ -249,7 +249,7 @@ void  Translate();
 
 #if NOT TRANSLATE
 #if NOT EXPANDABLE
-    ASSERT(Row <= Matrix->Size AND Col <= Matrix->Size);
+    assert(Row <= Matrix->Size AND Col <= Matrix->Size);
 #endif
 
 #if EXPANDABLE
@@ -442,7 +442,7 @@ register int IntRow, IntCol, ExtRow, ExtCol;
         IntRow = Matrix->CurrentSize;
 
 #if NOT EXPANDABLE
-        ASSERT(IntRow <= Matrix->Size);
+        assert(IntRow <= Matrix->Size);
 #endif
 
 #if EXPANDABLE
@@ -463,7 +463,7 @@ register int IntRow, IntCol, ExtRow, ExtCol;
         IntCol = Matrix->CurrentSize;
 
 #if NOT EXPANDABLE
-        ASSERT(IntCol <= Matrix->Size);
+        assert(IntCol <= Matrix->Size);
 #endif
 
 #if EXPANDABLE
@@ -1230,7 +1230,7 @@ void
 spInstallInitInfo( RealNumber* pElement, char* pInitInfo )
 {
 /* Begin `spInstallInitInfo'. */
-    ASSERT(pElement != NULL);
+    assert(pElement != NULL);
 
     ((ElementPtr)pElement)->pInitInfo = pInitInfo;
 }
@@ -1240,7 +1240,7 @@ char *
 spGetInitInfo( RealNumber* pElement )
 {
 /* Begin `spGetInitInfo'. */
-    ASSERT(pElement != NULL);
+    assert(pElement != NULL);
 
     return (char *)((ElementPtr)pElement)->pInitInfo;
 }
@@ -1254,7 +1254,7 @@ register ElementPtr pElement;
 int J, Error, Col;
 
 /* Begin `spInitialize'. */
-    ASSERT( IS_SPARSE( Matrix ) );
+    assert( IS_SPARSE( Matrix ) );
 
 #if spCOMPLEX
 /* Clear imaginary part of matrix if matrix is real but was complex. */

--- a/src/LinearAlgebraServicesPKG/ksparse/spdefs.h
+++ b/src/LinearAlgebraServicesPKG/ksparse/spdefs.h
@@ -347,7 +347,9 @@ static long padsize, padshift;
 
 
 
-
+/* NOTE:  Use of ASSERT is causing odd crashes in Xyce, and substitution
+   with the standard C assert() function seems to fix them.  I am disabling
+   this macro. */
 /*
  *  ASSERT and ABORT
  *
@@ -358,11 +360,13 @@ static long padsize, padshift;
  *  not evaluated unless the DEBUG flag is true.
  */
 
-#if DEBUG
-#define ASSERT(condition) if (NOT(condition)) ABORT()
-#else
-#define ASSERT(condition)
-#endif
+/*
+  #if DEBUG
+  #define ASSERT(condition) if (NOT(condition)) ABORT()
+  #else
+  #define ASSERT(condition)
+  #endif
+*/
 
 #ifndef ABORT
 #if DEBUG

--- a/src/LinearAlgebraServicesPKG/ksparse/spfactor.c
+++ b/src/LinearAlgebraServicesPKG/ksparse/spfactor.c
@@ -44,6 +44,7 @@ void FingerPrint (double *, int *, int *, int);
 */
 
 #include <sys/types.h>
+#include <assert.h>
 
 /*
  *  MATRIX FACTORIZATION MODULE
@@ -380,7 +381,7 @@ FILE *fmat;
 #endif
 
 /* Begin `spOrderAndFactor'. */
-    ASSERT( IS_VALID(Matrix) AND NOT Matrix->Factored);
+    assert( IS_VALID(Matrix) AND NOT Matrix->Factored);
 
 /*
     printf ("In spOrderAndFactor\n");
@@ -844,7 +845,7 @@ struct strip_out *strip, *old_strip, *my_strip, *prev_strip;
     minpiv_ratio = 1.;
     avgpiv_ratio = 0.;
 /* Begin `spFactor'. */
-    ASSERT( IS_VALID(Matrix) AND NOT Matrix->Factored);
+    assert( IS_VALID(Matrix) AND NOT Matrix->Factored);
 
     repartitioned = 0;
     if (my_context->Dsize < Size) {
@@ -1403,7 +1404,7 @@ int  Step, Size;
 ComplexNumber Mult, Pivot;
 
 /* Begin `FactorComplexMatrix'. */
-    ASSERT(Matrix->Complex);
+    assert(Matrix->Complex);
 
     Size = Matrix->Size;
     pElement = Matrix->Diag[1];
@@ -1553,7 +1554,7 @@ long flops;
    No is number of carryover columns from above row
 */
 /* Begin `spPartition'. */
-      ASSERT( IS_SPARSE( Matrix ) );
+      assert( IS_SPARSE( Matrix ) );
       if (Matrix->Partitioned) return;
       Size = Matrix->Size;
       DoRealDirect = Matrix->DoRealDirect;

--- a/src/LinearAlgebraServicesPKG/ksparse/spoutput.c
+++ b/src/LinearAlgebraServicesPKG/ksparse/spoutput.c
@@ -87,6 +87,8 @@ static char RCSid[] =
 #include "spmatrix.h"
 #include "spdefs.h"
 
+#include <assert.h>
+
 int Printer_Width = PRINTER_WIDTH;
 void spExpandFormat(MatrixPtr);
 
@@ -177,7 +179,7 @@ ElementPtr  pElement, *pImagElements;
 int  *PrintOrdToIntRowMap, *PrintOrdToIntColMap;
 
 /* Begin `spPrint'. */
-    ASSERT( IS_SPARSE( Matrix ) );
+    assert( IS_SPARSE( Matrix ) );
     spExpandFormat(Matrix);
     Size = Matrix->Size;
     CALLOC(pImagElements, ElementPtr, Printer_Width / 10 + 1);
@@ -453,7 +455,7 @@ int  Row, Col, Err;
 FILE  *pMatrixFile;
 
 /* Begin `spFileMatrix'. */
-    ASSERT( IS_SPARSE( Matrix ) );
+    assert( IS_SPARSE( Matrix ) );
     spExpandFormat(Matrix);
 
 /* Open file matrix file in write mode. */
@@ -604,7 +606,7 @@ register  int  I, Size, Err;
 FILE  *pMatrixFile;
 
 /* Begin `spFileVector'. */
-    ASSERT( IS_SPARSE( Matrix ) AND RHS != NULL)
+    assert( IS_SPARSE( Matrix ) AND RHS != NULL);
 
 /* Open File in append mode. */
     if ((pMatrixFile = fopen(File,"a")) == NULL)
@@ -616,7 +618,7 @@ FILE  *pMatrixFile;
     if (Matrix->Complex)
     {
 #if spSEPARATED_COMPLEX_VECTORS
-        ASSERT(iRHS != NULL)
+        assert(iRHS != NULL);
         --RHS;
         --iRHS;
 #else
@@ -724,7 +726,7 @@ RealNumber  Data, LargestElement, SmallestElement;
 FILE  *pStatsFile;
 
 /* Begin `spFileStats'. */
-    ASSERT( IS_SPARSE( Matrix ) );
+    assert( IS_SPARSE( Matrix ) );
     spExpandFormat(Matrix);
 
 /* Open File in append mode. */

--- a/src/LinearAlgebraServicesPKG/ksparse/spsolve.c
+++ b/src/LinearAlgebraServicesPKG/ksparse/spsolve.c
@@ -87,6 +87,7 @@ static char RCSid[] =
 #include "spconfig.h"
 #include "spmatrix.h"
 #include "spdefs.h"
+#include <assert.h>
 
 double total_solve_time;
 
@@ -237,10 +238,10 @@ double *orig_rhs;
     }
     else
     {
-      ASSERT( IS_VALID(Matrix));
+      assert( IS_VALID(Matrix));
     }
     spExpandFormat(Matrix);
-    ASSERT( IS_FACTORED(Matrix) );
+    assert( IS_FACTORED(Matrix) );
 
 #if spCOMPLEX
     if (Matrix->Complex)
@@ -358,7 +359,7 @@ register  int  I, *pExtOrder, Size;
 ElementPtr  pPivot;
 
 /* Begin `spSolve'. */
-    ASSERT( IS_VALID(Matrix));
+    assert( IS_VALID(Matrix));
 
 #if spCOMPLEX
     if (Matrix->Complex)
@@ -689,10 +690,10 @@ RealNumber  Temp;
     }
     else
     {
-      ASSERT( IS_VALID(Matrix));
+      assert( IS_VALID(Matrix));
     }
     spExpandFormat(Matrix);
-    ASSERT( IS_VALID(Matrix) AND IS_FACTORED(Matrix) );
+    assert( IS_VALID(Matrix) AND IS_FACTORED(Matrix) );
 
 #if spCOMPLEX
     if (Matrix->Complex)

--- a/src/LinearAlgebraServicesPKG/ksparse/sputils.c
+++ b/src/LinearAlgebraServicesPKG/ksparse/sputils.c
@@ -104,6 +104,8 @@ static char RCSid[] =
 #include "spmatrix.h"
 #include "spdefs.h"
 
+#include <assert.h>
+
 extern ElementPtr *returned_elements;
 extern int *num_returned_elements;
 void spExpandFormat(MatrixPtr);
@@ -372,7 +374,7 @@ BOOLEAN  Swapped, AnotherPassNeeded;
 
 /* Begin `spMNA_Preorder'. */
     spExpandFormat(Matrix);
-    ASSERT( IS_VALID(Matrix) AND NOT Matrix->Factored );
+    assert( IS_VALID(Matrix) AND NOT Matrix->Factored );
 
     if (Matrix->RowsLinked) return;
     Size = Matrix->Size;
@@ -569,7 +571,7 @@ RealNumber  ScaleFactor;
 
 /* Begin `spScale'. */
     spExpandFormat(Matrix);
-    ASSERT( IS_VALID(Matrix) AND NOT Matrix->Factored );
+    assert( IS_VALID(Matrix) AND NOT Matrix->Factored );
     if (NOT Matrix->RowsLinked) spcLinkRows( Matrix );
 
 #if spCOMPLEX
@@ -797,7 +799,7 @@ MatrixPtr  Matrix = (MatrixPtr)eMatrix;
 
 /* Begin `spMultiply'. */
     spExpandFormat(Matrix);
-    ASSERT( IS_SPARSE( Matrix ) AND NOT Matrix->Factored );
+    assert( IS_SPARSE( Matrix ) AND NOT Matrix->Factored );
     if (NOT Matrix->RowsLinked)
 	spcLinkRows(Matrix);
     if (NOT Matrix->InternalVectorsAllocated)
@@ -986,7 +988,7 @@ MatrixPtr  Matrix = (MatrixPtr)eMatrix;
 
 /* Begin `spMultTransposed'. */
     spExpandFormat(Matrix);
-    ASSERT( IS_SPARSE( Matrix ) AND NOT Matrix->Factored );
+    assert( IS_SPARSE( Matrix ) AND NOT Matrix->Factored );
     if (NOT Matrix->InternalVectorsAllocated)
 	spcCreateInternalVectors( Matrix );
 
@@ -1188,7 +1190,7 @@ ComplexNumber Pivot, cDeterminant;
 
 /* Begin `spDeterminant'. */
     spExpandFormat(Matrix);
-    ASSERT( IS_SPARSE( Matrix ) AND IS_FACTORED(Matrix) );
+    assert( IS_SPARSE( Matrix ) AND IS_FACTORED(Matrix) );
     *pExponent = 0;
 
     if (Matrix->Error == spSINGULAR)
@@ -1334,7 +1336,7 @@ struct FillinListNodeStruct  *pListNode;
 int fast_ind, fast_ind_done;
 
 /* Begin `spStripFills'. */
-    ASSERT( IS_SPARSE( Matrix ) );
+    assert( IS_SPARSE( Matrix ) );
     if (Matrix->Fillins == 0) return;
     Matrix->NeedsOrdering = YES;
 
@@ -1471,8 +1473,8 @@ int  Size, ExtRow, ExtCol;
 
 /* Begin `spDeleteRowAndCol'. */
 
-    ASSERT( IS_SPARSE(Matrix) AND Row > 0 AND Col > 0 );
-    ASSERT( Row <= Matrix->ExtSize AND Col <= Matrix->ExtSize );
+    assert( IS_SPARSE(Matrix) AND Row > 0 AND Col > 0 );
+    assert( Row <= Matrix->ExtSize AND Col <= Matrix->ExtSize );
 
     Size = Matrix->Size;
     ExtRow = Row;
@@ -1481,7 +1483,7 @@ int  Size, ExtRow, ExtCol;
 
     Row = Matrix->ExtToIntRowMap[Row];
     Col = Matrix->ExtToIntColMap[Col];
-    ASSERT( Row > 0 AND Col > 0 );
+    assert( Row > 0 AND Col > 0 );
 
 /* Move Row so that it is the last row in the matrix. */
     if (Row != Size) spcRowExchange( Matrix, Row, Size );
@@ -1585,7 +1587,7 @@ RealNumber MaxPivot, MinPivot, Mag;
 /* Begin `spPseudoCondition'. */
 
     spExpandFormat(Matrix);
-    ASSERT( IS_SPARSE(Matrix) AND IS_FACTORED(Matrix) );
+    assert( IS_SPARSE(Matrix) AND IS_FACTORED(Matrix) );
     if (Matrix->Error == spSINGULAR OR Matrix->Error == spZERO_DIAG)
         return 0.0;
 
@@ -1598,7 +1600,7 @@ RealNumber MaxPivot, MinPivot, Mag;
         else if (Mag < MinPivot)
             MinPivot = Mag;
     }
-    ASSERT( MaxPivot > 0.0);
+    assert( MaxPivot > 0.0);
     return MaxPivot / MinPivot;
 }
 #endif
@@ -1680,7 +1682,7 @@ RealNumber Linpack, OLeary, InvNormOfInverse;
 /* Begin `spCondition'. */
 
     spExpandFormat(Matrix);
-    ASSERT( IS_SPARSE(Matrix) AND IS_FACTORED(Matrix) );
+    assert( IS_SPARSE(Matrix) AND IS_FACTORED(Matrix) );
     *pError = Matrix->Error;
     if (Matrix->Error >= spFATAL) return 0.0;
     if (NormOfMatrix == 0.0)
@@ -2072,7 +2074,7 @@ RealNumber Max = 0.0, AbsRowSum;
 
 /* Begin `spNorm'. */
     spExpandFormat(Matrix);
-    ASSERT( IS_SPARSE(Matrix) AND NOT IS_FACTORED(Matrix) );
+    assert( IS_SPARSE(Matrix) AND NOT IS_FACTORED(Matrix) );
     if (NOT Matrix->RowsLinked) spcLinkRows( Matrix );
 
 /* Compute row sums. */
@@ -2189,7 +2191,7 @@ ComplexNumber cPivot;
 register ElementPtr pElement, pDiag;
 
 /* Begin `spLargestElement'. */
-    ASSERT( IS_SPARSE(Matrix) );
+    assert( IS_SPARSE(Matrix) );
     spExpandFormat(Matrix);
 #if REAL
     if (Matrix->Factored AND NOT Matrix->Complex)
@@ -2305,7 +2307,7 @@ RealNumber Reid, Gear;
 
 /* Begin `spRoundoff'. */
     spExpandFormat(Matrix);
-    ASSERT( IS_SPARSE(Matrix) AND IS_FACTORED(Matrix) );
+    assert( IS_SPARSE(Matrix) AND IS_FACTORED(Matrix) );
 
 /* Compute Barlow's bound if it is not given. */
     if (Rho < 0.0) Rho = spLargestElement( eMatrix );
@@ -2369,7 +2371,7 @@ int Row, Col, Error;
     if (eMatrix == NULL)
 	Error = spNO_MEMORY;
     else
-    {   ASSERT(((MatrixPtr)eMatrix)->ID == SPARSE_ID);
+    {   assert(((MatrixPtr)eMatrix)->ID == SPARSE_ID);
 	Error = ((MatrixPtr)eMatrix)->Error;
     }
 


### PR DESCRIPTION
KSparse uses a non-standard macro called ASSERT to accomplish what the C standard assert() function is supposed to do.

In ngspice they've replaced all that with standard assert calls.

In Xyce, I'm finding that all runs I've tried with ksparse are crashing with abort traps in these macro calls, even though when viewed in the debugger the condition appears to be true (it should abort only if false).

When I replace these nonstandard macro calls with standard C function calls, no assertion failure is detected.  So clearly there is something wrong with how the macro is written, but rather than fix that kludge with further kludges, I'm replacing them all with assert calls and calling it done.

I have tested this code on the netlists in GH-123 and GH-124, both of which were crashing this way.  After the fix, all those netlists run with "-linsolv ksparse" just fine.

While the netlist of GH-123 doesn't crash ksparse as it used to, it is dramatically slower than with KLU, so much so that I aborted the run before it completed.  The netlist of GH-124 runs just fine and produces the same results as KLU.

GH-123
GH-124
Closes GH-125