### PR TITLE
Apply fix to BSIM4.7 CGS and CGD output variable

### DIFF
--- a/src/DeviceModelPKG/OpenModels/N_DEV_MOSFET_B4.C
+++ b/src/DeviceModelPKG/OpenModels/N_DEV_MOSFET_B4.C
@@ -6922,8 +6922,8 @@ bool Instance::updatePrimaryState ()
   stoVec[li_store_Vdsat] = Vdsat;
   stoVec[li_store_Vth] = Vth;
   stoVec[li_store_Gds] = gds;
-  stoVec[li_store_Cgs] = CAPcgsb;
-  stoVec[li_store_Cgd] = CAPcgdb;
+  stoVec[li_store_Cgs] = cgsb;
+  stoVec[li_store_Cgd] = cgdb;
 
   // intrinsic capacitors:
   // Note the weirdness --- we have a "qg", "qb" and "qd" state variable,
@@ -10578,8 +10578,8 @@ bool Master::updateState (double * solVec, double * staVec, double * stoVec)
     stoVec[mi.li_store_Vth] = mi.Vth;
 
     stoVec[mi.li_store_Gds] = mi.gds;
-    stoVec[mi.li_store_Cgs] = mi.CAPcgsb;
-    stoVec[mi.li_store_Cgd] = mi.CAPcgdb;
+    stoVec[mi.li_store_Cgs] = mi.cgsb;
+    stoVec[mi.li_store_Cgd] = mi.cgdb;
 
     // intrinsic capacitors:
     // Note the wierdness --- we have a "qg", "qb" and "qd" state variable,

--- a/src/DeviceModelPKG/OpenModels/N_DEV_MOSFET_B4p61.C
+++ b/src/DeviceModelPKG/OpenModels/N_DEV_MOSFET_B4p61.C
@@ -2583,7 +2583,7 @@ bool Instance::updateIntermediateVars4p61_ ()
   ScalingFactor = 1.0e-9;
 
   // Don't do charge computations in DC sweeps.
-  if (getSolverState().tranopFlag || getSolverState().acopFlag || getSolverState().transientFlag)
+  if (getSolverState().tranopFlag || getSolverState().acopFlag || getSolverState().transientFlag || getSolverState().dcsweepFlag)
   {
     ChargeComputationNeeded = true;
   }

--- a/src/DeviceModelPKG/OpenModels/N_DEV_MOSFET_B4p70.C
+++ b/src/DeviceModelPKG/OpenModels/N_DEV_MOSFET_B4p70.C
@@ -2847,7 +2847,7 @@ bool Instance::updateIntermediateVars4p70_ ()
   ScalingFactor = 1.0e-9;
 
   // Don't do charge computations in DC sweeps.
-  if (getSolverState().tranopFlag || getSolverState().acopFlag || getSolverState().transientFlag)
+  if (getSolverState().tranopFlag || getSolverState().acopFlag || getSolverState().transientFlag || getSolverState().dcsweepFlag)
   {
     ChargeComputationNeeded = true;
   }

--- a/src/DeviceModelPKG/OpenModels/N_DEV_MOSFET_B4p82.C
+++ b/src/DeviceModelPKG/OpenModels/N_DEV_MOSFET_B4p82.C
@@ -2882,7 +2882,7 @@ bool Instance::updateIntermediateVars4p82_ ()
   ScalingFactor = 1.0e-9;
 
   // Don't do charge computations in DC sweeps.
-  if (getSolverState().tranopFlag || getSolverState().acopFlag || getSolverState().transientFlag)
+  if (getSolverState().tranopFlag || getSolverState().acopFlag || getSolverState().transientFlag || getSolverState().dcsweepFlag)
   {
     ChargeComputationNeeded = true;
   }


### PR DESCRIPTION
A user reported a dramatic error between Xyce's output of CGS for the BSIM4.7 model and that of a commercial simulator.  I found that I could reproduce that easily using one of the simplest netlists in the regression suite (BSIM4_v4p7/test1.cir).  I tracked the differences down to Xyce's setting of ChargeComputationNeeded and the choice of which variable to store for output (Xyce stores CAPcgsb  instead of cgsb).

The first one meant that cgsb was always zero for DC sweeps, and the latter meant that the wrong variable was being output.

This commit fixes this issue for CGS and also for CGD (which had the same mistake) for all three versions of BSIM4.   BSIM3 has the same problem, but that is not addressed here.

I have NOT fixed the issue that none of the output variables are appropriately scaled by the multiplicity.  That would be an issue that touches too many devices for a simple PR like this one.

Closes GH-128