### PR TITLE
Fix incorrect output of FD ASCII rawfile in sweeps

### DIFF
--- a/src/IOInterfacePKG/N_IO_OutputterFrequencyRawASCII.C
+++ b/src/IOInterfacePKG/N_IO_OutputterFrequencyRawASCII.C
@@ -339,18 +339,21 @@ void FrequencyRawAscii::doFinishOutput()
 {
   if (os_)
   {
-    // need to move file pointer back to header and
-    // write out the number of points.
-    long currentFelePost = os_->tellp();
+    if (numPoints_ != 0)
+    {
+      // need to move file pointer back to header and
+      // write out the number of points.
+      long currentFelePost = os_->tellp();
 
-    // locate the position for number of points
-    os_->seekp( numPointsPos_);
+      // locate the position for number of points
+      os_->seekp( numPointsPos_);
 
-    // overwrite blank space with value
-    (*os_) << numPoints_;
+      // overwrite blank space with value
+      (*os_) << numPoints_;
 
-    // move file pointer to the end again.
-    os_->seekp( currentFelePost);
+      // move file pointer to the end again.
+      os_->seekp( currentFelePost);
+    }
   }
 
   // reset numPoints_ as it is used as a flag


### PR DESCRIPTION
A user reported that when Xyce is asked to produce ASCII rawfiles (with the "-a" command line switch) and .print statements with "format=raw", the number of points is incorrect for every plot but the last if there is a .step statement in the netlist.

Xyce was overwriting the first character of the correct value with "0".

The same issue is not present for time-domain output.

That's because the doFinishOutput method of the raw ascii outputter for frequency domain didn't conditionalize output of the number of points on whether that number was zero or not, as the binary rawfile outputter does (and the time domain ascii rawfile outputter does).

This commit corrects the issue.

Closes GH-151