### PR TITLE
Update DOI and DOE CODE links

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,11 +41,12 @@ devices, or more.
 
 ### Citing Xyce
 
-If you use Xyce in your work, please cite it using the metadata provided at the
-[DOE CODE entry](https://www.osti.gov/doecode/biblio/2462) for Xyce. Citations
-in various formats, including APA and BibTeX, are provided at the bottom of
-that page. The DOI entry for Xyce is
-[10.11578/dc.20171025.1421](https://doi.org/10.11578/dc.20171025.1421).
+If you use Xyce in your work, please cite it using the metadata
+provided at the [DOE CODE
+entry](https://www.osti.gov/doecode/biblio/104392) for Xyce. Citations
+in various formats, including APA and BibTeX, are provided at the
+bottom of that page. The DOI entry for Xyce is
+[10.11578/dc.20230414.1](https://doi.org/10.11578/dc.20230414.1).
 
 __Brief Citation__:\
 Eric R. Keiter, Richard L. Schiek, Heidi K. Thornquist, Ting Mei, Jason C.


### PR DESCRIPTION
The DOI in README.md points to a very old DOE CODE page that has an incorrect link to a Github repository that isn't the Xyce team's and which contains an ancient version of Xyce 6.2 that hasn't been touched in 11 years.

This commit updates the DOE CODE link and the DOI to point to a much more recent version.

Closes GH-169