### PR TITLE
CMake(buildxyceplugin): synchronize functionality with Autotools variant

### DIFF
--- a/utils/XycePluginProject.cmake.in
+++ b/utils/XycePluginProject.cmake.in
@@ -22,8 +22,13 @@ link_directories("${XYCE_INSTALL}/lib")
 # Build shared library.
 add_compile_options("$<IF:$<CXX_COMPILER_ID:IntelLLVM>,-fp-model=precise,>")
 add_library("${library_name}" SHARED ${src_files})
+# remove "lib" prefix
+set_target_properties("${library_name}" PROPERTIES
+  PREFIX ""
+)
 target_include_directories("${library_name}" PUBLIC
   ${CMAKE_CURRENT_SOURCE_DIR}
   ${XYCE_INSTALL}/include
   "@Trilinos_INCLUDE_DIRS@")
   target_link_libraries("${library_name}" xyce)
+

--- a/utils/XycePluginProject.cmake.in
+++ b/utils/XycePluginProject.cmake.in
@@ -32,3 +32,6 @@ target_include_directories("${library_name}" PUBLIC
   "@Trilinos_INCLUDE_DIRS@")
   target_link_libraries("${library_name}" xyce)
 
+install(TARGETS "${library_name}"
+  LIBRARY DESTINATION "."
+)

--- a/utils/buildxyceplugin.cmake.in
+++ b/utils/buildxyceplugin.cmake.in
@@ -218,11 +218,19 @@ rm -f .headerstring_$$ .registerstring_$$
 
 # Use CMake to build this plugin.
 echo "Building plugin..."
+BUILDDIR="buildxyceplugin"
 cp ${XyceInstDir}/share/XycePluginProject.cmake ./CMakeLists.txt
-cmake -DCMAKE_CXX_COMPILER="@CMAKE_CXX_COMPILER@" -DPLUGIN_NAME="$pluginname" -DXYCE_INSTALL="$XyceInstDir" -DCMAKE_INSTALL_PREFIX="$DESTDIR" .
-cmake --build .
+cmake \
+    -DCMAKE_CXX_COMPILER="@CMAKE_CXX_COMPILER@" \
+    -DPLUGIN_NAME="$pluginname" \
+    -DXYCE_INSTALL="$XyceInstDir" \
+    -DCMAKE_INSTALL_PREFIX="$DESTDIR" \
+    -S . \
+    -B "$BUILDDIR"
+
+cmake --build "$BUILDDIR"
 # install library
-make install
+make -C "$BUILDDIR" install
 
 echo "Done!  Your plugin may now be used by running Xyce with the option '-plugin ${pluginname}.so'"
 echo "This plugin provides the Verilog-A modules: $modules"

--- a/utils/buildxyceplugin.cmake.in
+++ b/utils/buildxyceplugin.cmake.in
@@ -45,6 +45,15 @@ usage ()
     return
 }
 
+cleanup ()
+{
+    while [ $# -gt 0 ]
+    do
+        rm -f $1
+        shift
+    done
+}
+
 runadms()
 {
     admsXml -D__XYCE__ -x -e ${xmldir}/adms.implicit.xml -e ${xmldir}/xyceVersion_nosac.xml  -e ${xmldir}/xyceBasicTemplates_nosac.xml \
@@ -130,7 +139,6 @@ shift `echo $OPTIND-1 | bc`
 headerstring=""
 registerstring=""
 CLEANFILES=""
-OBJFILES=""
 
 scanargs $@
 if [ $? != 0  -o "${VAFILES}x" = "x" ]
@@ -176,15 +184,8 @@ do
        modules=${module}" "${modules}
        echo "#include <N_DEV_ADMS${module}.h>" >> .headerstring_$$
        echo "Xyce::Device::ADMS${module}::registerDevice();" >> .registerstring_$$
-       if [ $? -ne 0 ]
-       then
-           echo "Compilation of N_DEV_ADMS${module}.C failed"
-           echo "See buildxyceplugin.log for details"
-           exit 1
-       else
-           CLEANFILES="${CLEANFILES} ${CXXFIL} ${OBJFIL} N_DEV_ADMS${module}.h"
-       fi
-       OBJFILES="$OBJFILES N_DEV_ADMS${module}.lo"
+       # add all ADMS files to CLEANFILES
+       CLEANFILES="${CLEANFILES} N_DEV_ADMS${module}.h N_DEV_ADMS${module}.C buildxyceplugin.log"
 
        count=`echo $count+1|bc`
     else
@@ -215,6 +216,7 @@ echo "};" >>   ${pluginname}_bootstrap.C
 echo "Bootstrap s_bootstrap;" >>   ${pluginname}_bootstrap.C
 
 rm -f .headerstring_$$ .registerstring_$$
+CLEANFILES="${CLEANFILES} ${pluginname}_bootstrap.C"
 
 # Use CMake to build this plugin.
 echo "Building plugin..."
@@ -234,3 +236,17 @@ make -C "$BUILDDIR" install
 
 echo "Done!  Your plugin may now be used by running Xyce with the option '-plugin ${pluginname}.so'"
 echo "This plugin provides the Verilog-A modules: $modules"
+
+# cleanup ADMS files and CMakeLists.txt
+cleanup "${CLEANFILES} CMakeLists.txt"
+cleanup .adms*.xml .interface*.xml .*.adms constants.vams disciplines.vams discipline.h
+
+# cleanup CMake build folder if we have installed the target successfully
+if [ -f "${DESTDIR}/${pluginname}.so" ]; then
+    if [ -d "$BUILDDIR" ]; then
+        rm -rf "$BUILDDIR"
+    fi
+else
+    echo "Installation of plugin to directory: '$(realpath $DESTDIR)' - failed"
+    echo "You can find the plugin in build directory: '$(realpath $BUILDDIR)'"
+fi

--- a/utils/buildxyceplugin.cmake.in
+++ b/utils/buildxyceplugin.cmake.in
@@ -139,8 +139,6 @@ then
     exit 1
 fi
 
-cd $DESTDIR
-
 echo "buildxyceplugin is building a plugin from the Verilog-A files:"
 echo ${VAFILES}
 if [ "${pluginname}x" = "x" ]

--- a/utils/buildxyceplugin.cmake.in
+++ b/utils/buildxyceplugin.cmake.in
@@ -219,8 +219,10 @@ rm -f .headerstring_$$ .registerstring_$$
 # Use CMake to build this plugin.
 echo "Building plugin..."
 cp ${XyceInstDir}/share/XycePluginProject.cmake ./CMakeLists.txt
-cmake -DCMAKE_CXX_COMPILER="@CMAKE_CXX_COMPILER@" -DPLUGIN_NAME="$pluginname" -DXYCE_INSTALL="$XyceInstDir" .
+cmake -DCMAKE_CXX_COMPILER="@CMAKE_CXX_COMPILER@" -DPLUGIN_NAME="$pluginname" -DXYCE_INSTALL="$XyceInstDir" -DCMAKE_INSTALL_PREFIX="$DESTDIR" .
 cmake --build .
+# install library
+make install
 
 echo "Done!  Your plugin may now be used by running Xyce with the option '-plugin ${pluginname}.so'"
 echo "This plugin provides the Verilog-A modules: $modules"


### PR DESCRIPTION
This PR is to try and synchronize feature(s) between the Autotools/Make based script `buildxyceplugin.in` and the CMake based flow (`buildxyce.plugin.cmake.in` and `XycePluginProject.cmake.in`).

Short summary of changes
---

1. Remove `cd $DESTDIR` to fix relative input paths
2. Remove `lib` prefix of output files that CMake adds automatically to library files
   - This way the script and compiled output from CMake has the same name
3. Make installation target to install the file to `$DESTDIR`
4. Compile to an explicit `$BUILDDIR` for easier cleanup
5. Do the actual cleanup
    - Re-introduce the cleanup function from `buildxyceplugin`
    - Clean up ADMS files
    - Conditionally remove the build directory, depending on whether we installed the library file as expected
  
I _think_ it now matches better with the "old" way of compiling plugins, but I am of course open for changes/suggestions!

Testing
---

I tested to compile IHP's plugins/models, found [here](https://github.com/IHP-GmbH/IHP-Open-PDK/tree/dev/ihp-sg13g2/libs.tech/verilog-a) and they seem to be working as expected!

Draft/TODOs
---

I'll leave this PR as a patch series in draft mode for easier rebasing/cherry-picking/dropping of commits in case we want any changes.
When/If it gets OK'd, I'll squash the commits to a single one (or multiple if preferred).

Fixes: https://github.com/Xyce/Xyce/issues/172